### PR TITLE
Bump Symfony 6 support to ^6.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@ jobs:
           - description: 'Symfony 5.4'
             php: '7.4'
             symfony: 5.4.*
-          - description: 'Symfony 6.2'
+          - description: 'Symfony 6.3'
             php: '8.2'
-            symfony: 6.2.*
+            symfony: 6.3.*
     name: PHPStan - PHP ${{ matrix.php }} tests (${{ matrix.description }})
     steps:
       - name: Checkout
@@ -61,6 +61,9 @@ jobs:
           - description: 'Symfony 6.3'
             php: '8.2'
             symfony: 6.3
+          - description: 'Symfony 6.4'
+            php: '8.2'
+            symfony: 6.4.*-dev
     name: PHP ${{ matrix.php }} tests (${{ matrix.description }})
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,12 +58,9 @@ jobs:
           - description: 'Symfony 5.4'
             php: '8.2'
             symfony: 5.4.*
-          - description: 'Symfony 6.2'
-            php: '8.2'
-            symfony: 6.2.*
           - description: 'Symfony 6.3'
             php: '8.2'
-            symfony: 6.3.*-dev
+            symfony: 6.3
     name: PHP ${{ matrix.php }} tests (${{ matrix.description }})
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     "require": {
         "php": "7.4.* || 8.0.* || 8.1.* || 8.2.*",
         "pontedilana/php-weasyprint": "^1.0",
-        "symfony/config": "^5.4 || ^6.2",
-        "symfony/dependency-injection": "^5.4 || ^6.2",
-        "symfony/http-foundation": "^5.4 || ^6.2",
-        "symfony/http-kernel": "^5.4 || ^6.2"
+        "symfony/config": "^5.4 || ^6.3",
+        "symfony/dependency-injection": "^5.4 || ^6.3",
+        "symfony/http-foundation": "^5.4 || ^6.3",
+        "symfony/http-kernel": "^5.4 || ^6.3"
     },
     "require-dev": {
         "doctrine/annotations": "^1.11",
@@ -31,10 +31,10 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/framework-bundle": "^5.4 || ^6.2",
-        "symfony/phpunit-bridge": "^5.4 || ^6.2",
-        "symfony/validator": "^5.4 || ^6.2",
-        "symfony/yaml": "^5.4 || ^6.2"
+        "symfony/framework-bundle": "^5.4 || ^6.3",
+        "symfony/phpunit-bridge": "^5.4 || ^6.3",
+        "symfony/validator": "^5.4 || ^6.3",
+        "symfony/yaml": "^5.4 || ^6.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As Symfony/* `6.2` is not maintained anymore.